### PR TITLE
Building block (bk) based feature table writer

### DIFF
--- a/lib/bk/bkblock.c
+++ b/lib/bk/bkblock.c
@@ -41,7 +41,6 @@ void bkblock_pushptr(caryll_bkblock *b, bk_cell_type type, caryll_bkblock *p) {
 	bk_cell *cell = bkblock_grow(b, 1);
 	cell->t = type;
 	cell->p = p;
-	b->_stem = true;
 }
 
 static void vbkpushitems(caryll_bkblock *b, bk_cell_type type0, va_list ap) {

--- a/lib/bk/bkblock.c
+++ b/lib/bk/bkblock.c
@@ -1,0 +1,61 @@
+#include "bkblock.h"
+
+static void bkblock_acells(caryll_bkblock *b, size_t len) {
+	if (len <= b->length + b->free) {
+		// We have enough space
+		b->free -= len - b->length;
+		b->length = len;
+	} else {
+		// allocate space
+		b->length = len;
+		b->free = (len >> 1) & 0xFFFFFF;
+		if (b->cells) {
+			b->cells = realloc(b->cells, sizeof(bk_cell) * (b->length + b->free));
+		} else {
+			b->cells = malloc(sizeof(bk_cell) * (b->length + b->free));
+		}
+	}
+}
+static bk_cell *bkblock_grow(caryll_bkblock *b, size_t len) {
+	size_t olen = b->length;
+	bkblock_acells(b, olen + len);
+	return &(b->cells[olen]);
+}
+
+caryll_bkblock *_bkblock_init() {
+	caryll_bkblock *b = calloc(1, sizeof(caryll_bkblock));
+	bkblock_acells(b, 0);
+	return b;
+}
+
+void bkblock_push1(caryll_bkblock *b, bk_cell_type type, uint32_t x) {
+	bk_cell *cell = bkblock_grow(b, 1);
+	cell->t = type, cell->z = x;
+	if (type >= p16) b->_leaf = false;
+}
+
+static void vbkpushitems(caryll_bkblock *b, bk_cell_type type0, va_list ap) {
+	bk_cell_type curtype = type0;
+	while (curtype) {
+		uint32_t par = va_arg(ap, int);
+		bkblock_push1(b, curtype, par);
+		curtype = va_arg(ap, int);
+	}
+}
+
+caryll_bkblock *new_bkblock(bk_cell_type type0, ...) {
+	va_list ap;
+	va_start(ap, type0);
+	caryll_bkblock *b = _bkblock_init();
+	vbkpushitems(b, type0, ap);
+	va_end(ap);
+	return b;
+}
+
+caryll_bkblock *bkblock_push(caryll_bkblock *b, bk_cell_type type0, ...) {
+	va_list ap;
+	va_start(ap, type0);
+	vbkpushitems(b, type0, ap);
+	va_end(ap);
+	return b;
+}

--- a/lib/bk/bkblock.c
+++ b/lib/bk/bkblock.c
@@ -47,7 +47,22 @@ void bkblock_pushptr(caryll_bkblock *b, bk_cell_type type, caryll_bkblock *p) {
 static void vbkpushitems(caryll_bkblock *b, bk_cell_type type0, va_list ap) {
 	bk_cell_type curtype = type0;
 	while (curtype) {
-		if (curtype < p16) {
+		if (curtype == bembed) {
+			caryll_bkblock *par = va_arg(ap, caryll_bkblock *);
+			if (par && par->cells) {
+				for (uint32_t j = 0; j < par->length; j++) {
+					if (bk_cell_is_ptr(par->cells + j)) {
+						bkblock_pushptr(b, par->cells[j].t, par->cells[j].p);
+					} else {
+						bkblock_pushint(b, par->cells[j].t, par->cells[j].z);
+					}
+				}
+			}
+			if (par) {
+				free(par->cells);
+				free(par);
+			}
+		} else if (curtype < p16) {
 			uint32_t par = va_arg(ap, int);
 			bkblock_pushint(b, curtype, par);
 		} else {

--- a/lib/bk/bkblock.c
+++ b/lib/bk/bkblock.c
@@ -16,6 +16,10 @@ static void bkblock_acells(caryll_bkblock *b, size_t len) {
 		}
 	}
 }
+bool bk_cell_is_ptr(bk_cell *cell) {
+	return cell->t >= p16;
+}
+
 static bk_cell *bkblock_grow(caryll_bkblock *b, size_t len) {
 	size_t olen = b->length;
 	bkblock_acells(b, olen + len);
@@ -28,17 +32,28 @@ caryll_bkblock *_bkblock_init() {
 	return b;
 }
 
-void bkblock_push1(caryll_bkblock *b, bk_cell_type type, uint32_t x) {
+void bkblock_pushint(caryll_bkblock *b, bk_cell_type type, uint32_t x) {
 	bk_cell *cell = bkblock_grow(b, 1);
-	cell->t = type, cell->z = x;
-	if (type >= p16) b->_leaf = false;
+	cell->t = type;
+	cell->z = x;
+}
+void bkblock_pushptr(caryll_bkblock *b, bk_cell_type type, caryll_bkblock *p) {
+	bk_cell *cell = bkblock_grow(b, 1);
+	cell->t = type;
+	cell->p = p;
+	b->_stem = true;
 }
 
 static void vbkpushitems(caryll_bkblock *b, bk_cell_type type0, va_list ap) {
 	bk_cell_type curtype = type0;
 	while (curtype) {
-		uint32_t par = va_arg(ap, int);
-		bkblock_push1(b, curtype, par);
+		if (curtype < p16) {
+			uint32_t par = va_arg(ap, int);
+			bkblock_pushint(b, curtype, par);
+		} else {
+			caryll_bkblock *par = va_arg(ap, caryll_bkblock *);
+			bkblock_pushptr(b, curtype, par);
+		}
 		curtype = va_arg(ap, int);
 	}
 }
@@ -58,4 +73,30 @@ caryll_bkblock *bkblock_push(caryll_bkblock *b, bk_cell_type type0, ...) {
 	vbkpushitems(b, type0, ap);
 	va_end(ap);
 	return b;
+}
+
+caryll_bkblock *new_bkblock_from_buffer(/*MOVE*/ caryll_buffer *buf) {
+	caryll_bkblock *b = new_bkblock(bkover);
+	for (size_t j = 0; j < buf->size; j++) {
+		bkblock_pushint(b, b8, buf->data[j]);
+	}
+	buffree(buf);
+	return b;
+}
+
+void print_bkblock(caryll_bkblock *b) {
+	fprintf(stderr, "Block size %08x\n", (uint32_t)b->length);
+	fprintf(stderr, "------------------\n");
+	for (uint32_t j = 0; j < b->length; j++) {
+		if (bk_cell_is_ptr(b->cells + j)) {
+			if (b->cells[j].p) {
+				fprintf(stderr, "  %3d %p[%d]\n", b->cells[j].t, b->cells[j].p, b->cells[j].p->_index);
+			} else {
+				fprintf(stderr, "  %3d [NULL]\n", b->cells[j].t);
+			}
+		} else {
+			fprintf(stderr, "  %3d %d\n", b->cells[j].t, b->cells[j].z);
+		}
+	}
+	fprintf(stderr, "------------------\n");
 }

--- a/lib/bk/bkblock.h
+++ b/lib/bk/bkblock.h
@@ -1,0 +1,34 @@
+#ifndef CARYLL_BK_BLOCK_H
+#define CARYLL_BK_BLOCK_H
+
+#include <stdint.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+struct __caryll_bkblock;
+typedef enum {
+	bkover = 0, // nothing
+	b8 = 1,     // byte
+	b16 = 2,    // short
+	b32 = 3,    // long
+	p16 = 0x10, // 16-bit offset, z = forest index
+	p32 = 0x11  // 32-bit offset, z = forest index
+} bk_cell_type;
+
+typedef struct {
+	bk_cell_type t;
+	uint32_t z;
+} bk_cell;
+
+typedef struct __caryll_bkblock {
+	bool _leaf;
+	size_t length;
+	size_t free;
+	bk_cell *cells;
+} caryll_bkblock;
+
+caryll_bkblock *_bkblock_init();
+caryll_bkblock *new_bkblock(bk_cell_type type0, ...);
+
+#endif

--- a/lib/bk/bkblock.h
+++ b/lib/bk/bkblock.h
@@ -5,6 +5,7 @@
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdlib.h>
+#include <support/buffer.h>
 
 struct __caryll_bkblock;
 typedef enum {
@@ -12,17 +13,23 @@ typedef enum {
 	b8 = 1,     // byte
 	b16 = 2,    // short
 	b32 = 3,    // long
-	p16 = 0x10, // 16-bit offset, z = forest index
-	p32 = 0x11  // 32-bit offset, z = forest index
+	p16 = 0x10, // 16-bit offset, p = pointer to block
+	p32 = 0x11  // 32-bit offset, p = pointer to block
 } bk_cell_type;
+typedef enum { VISIT_WHITE, VISIT_GRAY, VISIT_BLACK } bk_cell_visit_state;
 
 typedef struct {
 	bk_cell_type t;
-	uint32_t z;
+	union {
+		uint32_t z;
+		struct __caryll_bkblock *p;
+	};
 } bk_cell;
 
 typedef struct __caryll_bkblock {
-	bool _leaf;
+	bool _stem;
+	bk_cell_visit_state _visitstate;
+	uint32_t _index;
 	size_t length;
 	size_t free;
 	bk_cell *cells;
@@ -30,5 +37,9 @@ typedef struct __caryll_bkblock {
 
 caryll_bkblock *_bkblock_init();
 caryll_bkblock *new_bkblock(bk_cell_type type0, ...);
+caryll_bkblock *bkblock_push(caryll_bkblock *b, bk_cell_type type0, ...);
+caryll_bkblock *new_bkblock_from_buffer(/*MOVE*/ caryll_buffer *buf);
+bool bk_cell_is_ptr(bk_cell *cell);
+void print_bkblock(caryll_bkblock *b);
 
 #endif

--- a/lib/bk/bkblock.h
+++ b/lib/bk/bkblock.h
@@ -9,12 +9,13 @@
 
 struct __caryll_bkblock;
 typedef enum {
-	bkover = 0, // nothing
-	b8 = 1,     // byte
-	b16 = 2,    // short
-	b32 = 3,    // long
-	p16 = 0x10, // 16-bit offset, p = pointer to block
-	p32 = 0x11  // 32-bit offset, p = pointer to block
+	bkover = 0,   // nothing
+	b8 = 1,       // byte
+	b16 = 2,      // short
+	b32 = 3,      // long
+	p16 = 0x10,   // 16-bit offset, p = pointer to block
+	p32 = 0x11,   // 32-bit offset, p = pointer to block
+	bembed = 0xFF // Embed another block
 } bk_cell_type;
 typedef enum { VISIT_WHITE, VISIT_GRAY, VISIT_BLACK } bk_cell_visit_state;
 

--- a/lib/bk/bkblock.h
+++ b/lib/bk/bkblock.h
@@ -28,9 +28,9 @@ typedef struct {
 } bk_cell;
 
 typedef struct __caryll_bkblock {
-	bool _stem;
 	bk_cell_visit_state _visitstate;
 	uint32_t _index;
+	uint32_t _height;
 	size_t length;
 	size_t free;
 	bk_cell *cells;

--- a/lib/bk/bkgraph.c
+++ b/lib/bk/bkgraph.c
@@ -1,0 +1,238 @@
+#include "bkgraph.h"
+
+static bkgraph_entry *_bkgraph_grow(caryll_bkgraph *f) {
+	if (f->free) {
+		f->length++;
+		f->free--;
+	} else {
+		f->length = f->length + 1;
+		f->free = (f->length >> 1) & 0xFFFFFF;
+		if (f->entries) {
+			f->entries = realloc(f->entries, (f->length + f->free) * sizeof(bkgraph_entry));
+		} else {
+			f->entries = malloc((f->length + f->free) * sizeof(bkgraph_entry));
+		}
+	}
+	return &(f->entries[f->length - 1]);
+}
+
+static bkgraph_entry *dfs_insert_cells(caryll_bkblock *b, caryll_bkgraph *f, uint32_t *order) {
+	if (!b || b->_visitstate != VISIT_WHITE) return NULL;
+	b->_visitstate = VISIT_GRAY;
+	uint32_t height = 0;
+	for (uint32_t j = 0; j < b->length; j++) {
+		bk_cell *cell = &(b->cells[j]);
+		if (bk_cell_is_ptr(cell) && cell->p) {
+			bkgraph_entry *e = dfs_insert_cells(cell->p, f, order);
+			if (e && e->height + 1 > height) height = e->height + 1;
+		}
+	}
+	bkgraph_entry *e = _bkgraph_grow(f);
+	e->alias = 0;
+	e->block = b;
+	*order += 1;
+	e->order = *order;
+	e->height = height;
+	b->_visitstate = VISIT_BLACK;
+	return e;
+}
+
+static int _by_order(const void *_a, const void *_b) {
+	const bkgraph_entry *a = _a;
+	const bkgraph_entry *b = _b;
+	return a->height == b->height ? a->order - b->order : b->height - a->height;
+}
+
+caryll_bkgraph *caryll_bkgraph_from_block(caryll_bkblock *b) {
+	caryll_bkgraph *forest = calloc(1, sizeof(caryll_bkgraph));
+	uint32_t tsOrder = 0;
+	dfs_insert_cells(b, forest, &tsOrder);
+	qsort(forest->entries, forest->length, sizeof(bkgraph_entry), _by_order);
+	for (uint32_t j = 0; j < forest->length; j++) {
+		forest->entries[j].block->_index = j;
+		forest->entries[j].alias = j;
+	}
+	return forest;
+}
+
+void caryll_delete_bkgraph(caryll_bkgraph *f) {
+	if (!f || !f->entries) return;
+	for (uint32_t j = 0; j < f->length; j++) {
+		caryll_bkblock *b = f->entries[j].block;
+		if (b && b->cells) free(b->cells);
+		free(b);
+	}
+	free(f->entries);
+}
+static size_t caryll_bkblock_size(caryll_bkblock *b) {
+	size_t size = 0;
+	for (uint32_t j = 0; j < b->length; j++)
+		switch (b->cells[j].t) {
+			case b8:
+				size += 1;
+				break;
+			case b16:
+			case p16:
+				size += 2;
+				break;
+			case b32:
+			case p32:
+				size += 4;
+				break;
+			default:
+				break;
+		}
+	return size;
+}
+
+static uint32_t getoffset(size_t *offsets, caryll_bkblock *ref, caryll_bkblock *target, uint8_t bits) {
+	size_t offref = offsets[ref->_index];
+	size_t offtgt = offsets[target->_index];
+	if (offtgt < offref || (offtgt - offref) >> bits) {
+		fprintf(stderr, "[otfcc-fea] Warning : Unable to fit offset %d into %d bits.\n", (int32_t)(offtgt - offref),
+		        bits);
+	}
+	return (uint32_t)(offtgt - offref);
+}
+static void caryll_write_bkblock(caryll_buffer *buf, caryll_bkblock *b, size_t *offsets) {
+	for (uint32_t j = 0; j < b->length; j++) {
+		switch (b->cells[j].t) {
+			case b8:
+				bufwrite8(buf, b->cells[j].z);
+				break;
+			case b16:
+				bufwrite16b(buf, b->cells[j].z);
+				break;
+			case b32:
+				bufwrite32b(buf, b->cells[j].z);
+				break;
+			case p16:
+				if (b->cells[j].p) {
+					bufwrite16b(buf, getoffset(offsets, b, b->cells[j].p, 16));
+				} else {
+					bufwrite16b(buf, 0);
+				}
+				break;
+			case p32:
+				if (b->cells[j].p) {
+					bufwrite16b(buf, getoffset(offsets, b, b->cells[j].p, 32));
+				} else {
+					bufwrite32b(buf, 0);
+				}
+				break;
+			default:
+				break;
+		}
+	}
+}
+
+static uint32_t gethash(caryll_bkblock *b) {
+	uint32_t h = 5381;
+	for (uint32_t j = 0; j < b->length; j++) {
+		h = ((h << 5) + h) + b->cells[j].t;
+		h = ((h << 5) + h);
+		switch (b->cells[j].t) {
+			case b8:
+			case b16:
+			case b32:
+				h += b->cells[j].z;
+				break;
+			case p16:
+			case p32:
+				if (b->cells[j].p) { h += b->cells[j].p->_index; }
+				break;
+			default:
+				break;
+		}
+	}
+	return h;
+}
+
+static bool compareblock(caryll_bkblock *a, caryll_bkblock *b) {
+	if (!a && !b) return true;
+	if (!a || !b) return false;
+	if (a->length != b->length) return false;
+	for (uint16_t j = 0; j < a->length; j++) {
+		if (a->cells[j].t != b->cells[j].t) return false;
+		switch (a->cells[j].t) {
+			case b8:
+			case b16:
+			case b32:
+				if (a->cells[j].z != b->cells[j].z) return false;
+				break;
+			case p16:
+			case p32:
+				if (a->cells[j].p != b->cells[j].p) return false;
+				break;
+			default:
+				break;
+		}
+	}
+	return true;
+}
+static bool compareEntry(bkgraph_entry *a, bkgraph_entry *b) {
+	if (a->hash != b->hash) return false;
+	return compareblock(a->block, b->block);
+}
+
+static void replaceptr(caryll_bkgraph *f, caryll_bkblock *b) {
+	for (uint32_t j = 0; j < b->length; j++) {
+		switch (b->cells[j].t) {
+			case p16:
+			case p32:
+				if (b->cells[j].p) {
+					uint32_t index = b->cells[j].p->_index;
+					while (f->entries[index].alias != index) {
+						index = f->entries[index].alias;
+					}
+					b->cells[j].p = f->entries[index].block;
+				}
+				break;
+			default:
+				break;
+		}
+	}
+}
+
+void caryll_minimize_bkgraph(caryll_bkgraph *f) {
+	uint32_t rear = (uint32_t)(f->length - 1);
+	uint32_t front = rear;
+	while (f->entries[front].height == f->entries[rear].height && front > 0) {
+		front--;
+	}
+	front++;
+	for (uint32_t j = front; j <= rear; j++) {
+		f->entries[j].hash = gethash(f->entries[j].block);
+	}
+	for (uint32_t j = front; j <= rear; j++) {
+		bkgraph_entry *a = &(f->entries[j]);
+		if (a->alias == j) {
+			for (uint32_t k = j + 1; k <= rear; k++) {
+				bkgraph_entry *b = &(f->entries[k]);
+				if (b->alias == k && compareEntry(a, b)) { b->alias = j; }
+			}
+		}
+	}
+	// replace pointers with aliased
+	for (uint32_t j = 0; j < front; j++) {
+		replaceptr(f, f->entries[j].block);
+	}
+}
+
+caryll_buffer *caryll_write_bkgraph(caryll_bkgraph *f) {
+	caryll_buffer *buf = bufnew();
+	size_t *offsets = calloc(f->length + 1, sizeof(size_t));
+	offsets[0] = 0;
+	size_t validEncs = 0;
+	for (uint32_t j = 0; j < f->length; j++) {
+		if (f->entries[j].alias == j) {
+			offsets[j + 1] = offsets[j] + caryll_bkblock_size(f->entries[j].block);
+			validEncs += 1;
+		} else {
+			offsets[j + 1] = offsets[j];
+		}
+	}
+	for (uint32_t j = 0; j < f->length; j++)
+		if (f->entries[j].alias == j) { caryll_write_bkblock(buf, f->entries[j].block, offsets); }
+	return buf;
+}

--- a/lib/bk/bkgraph.c
+++ b/lib/bk/bkgraph.c
@@ -236,3 +236,11 @@ caryll_buffer *caryll_write_bkgraph(caryll_bkgraph *f) {
 		if (f->entries[j].alias == j) { caryll_write_bkblock(buf, f->entries[j].block, offsets); }
 	return buf;
 }
+
+caryll_buffer *caryll_write_bk(/*MOVE*/ caryll_bkblock *root) {
+	caryll_bkgraph *f = caryll_bkgraph_from_block(root);
+	caryll_minimize_bkgraph(f);
+	caryll_buffer *buf = caryll_write_bkgraph(f);
+	caryll_delete_bkgraph(f);
+	return buf;
+}

--- a/lib/bk/bkgraph.c
+++ b/lib/bk/bkgraph.c
@@ -196,26 +196,29 @@ static void replaceptr(caryll_bkgraph *f, caryll_bkblock *b) {
 
 void caryll_minimize_bkgraph(caryll_bkgraph *f) {
 	uint32_t rear = (uint32_t)(f->length - 1);
-	uint32_t front = rear;
-	while (f->entries[front].height == f->entries[rear].height && front > 0) {
-		front--;
-	}
-	front++;
-	for (uint32_t j = front; j <= rear; j++) {
-		f->entries[j].hash = gethash(f->entries[j].block);
-	}
-	for (uint32_t j = front; j <= rear; j++) {
-		bkgraph_entry *a = &(f->entries[j]);
-		if (a->alias == j) {
-			for (uint32_t k = j + 1; k <= rear; k++) {
-				bkgraph_entry *b = &(f->entries[k]);
-				if (b->alias == k && compareEntry(a, b)) { b->alias = j; }
+	while (rear > 0) {
+		uint32_t front = rear;
+		while (f->entries[front].height == f->entries[rear].height && front > 0) {
+			front--;
+		}
+		front++;
+		for (uint32_t j = front; j <= rear; j++) {
+			f->entries[j].hash = gethash(f->entries[j].block);
+		}
+		for (uint32_t j = front; j <= rear; j++) {
+			bkgraph_entry *a = &(f->entries[j]);
+			if (a->alias == j) {
+				for (uint32_t k = j + 1; k <= rear; k++) {
+					bkgraph_entry *b = &(f->entries[k]);
+					if (b->alias == k && compareEntry(a, b)) { b->alias = j; }
+				}
 			}
 		}
-	}
-	// replace pointers with aliased
-	for (uint32_t j = 0; j < front; j++) {
-		replaceptr(f, f->entries[j].block);
+		// replace pointers with aliased
+		for (uint32_t j = 0; j < front; j++) {
+			replaceptr(f, f->entries[j].block);
+		}
+		rear = front - 1;
 	}
 }
 

--- a/lib/bk/bkgraph.c
+++ b/lib/bk/bkgraph.c
@@ -115,7 +115,7 @@ static void caryll_write_bkblock(caryll_buffer *buf, caryll_bkblock *b, size_t *
 				break;
 			case p32:
 				if (b->cells[j].p) {
-					bufwrite16b(buf, getoffset(offsets, b, b->cells[j].p, 32));
+					bufwrite32b(buf, getoffset(offsets, b, b->cells[j].p, 32));
 				} else {
 					bufwrite32b(buf, 0);
 				}

--- a/lib/bk/bkgraph.h
+++ b/lib/bk/bkgraph.h
@@ -24,8 +24,9 @@ typedef struct {
 } caryll_bkgraph;
 
 caryll_bkgraph *caryll_bkgraph_from_block(caryll_bkblock *b);
-void caryll_delete_bkgraph(caryll_bkgraph *f);
-void caryll_minimize_bkgraph(caryll_bkgraph *f);
-caryll_buffer *caryll_write_bkgraph(caryll_bkgraph *f);
+void caryll_delete_bkgraph(/*MOVE*/ caryll_bkgraph *f);
+void caryll_minimize_bkgraph(/*BORROW*/ caryll_bkgraph *f);
+caryll_buffer *caryll_write_bkgraph(/*BORROW*/ caryll_bkgraph *f);
+caryll_buffer *caryll_write_bk(/*MOVE*/ caryll_bkblock *root);
 
 #endif

--- a/lib/bk/bkgraph.h
+++ b/lib/bk/bkgraph.h
@@ -1,0 +1,31 @@
+#ifndef CARYLL_BK_BKGRAPH_H
+#define CARYLL_BK_BKGRAPH_H
+
+#include <stdint.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <support/buffer.h>
+
+#include "bkblock.h"
+
+typedef struct {
+	uint32_t alias;
+	uint32_t order;
+	uint32_t height;
+	uint32_t hash;
+	caryll_bkblock *block;
+} bkgraph_entry;
+
+typedef struct {
+	size_t length;
+	size_t free;
+	bkgraph_entry *entries;
+} caryll_bkgraph;
+
+caryll_bkgraph *caryll_bkgraph_from_block(caryll_bkblock *b);
+void caryll_delete_bkgraph(caryll_bkgraph *f);
+void caryll_minimize_bkgraph(caryll_bkgraph *f);
+caryll_buffer *caryll_write_bkgraph(caryll_bkgraph *f);
+
+#endif

--- a/lib/tables/otl/chaining.c
+++ b/lib/tables/otl/chaining.c
@@ -490,11 +490,7 @@ caryll_buffer *caryll_write_chaining_coverage(otl_subtable *_subtable) {
 		             bkover);
 	}
 
-	caryll_bkgraph *f = caryll_bkgraph_from_block(root);
-	caryll_minimize_bkgraph(f);
-	caryll_buffer *buf = caryll_write_bkgraph(f);
-	caryll_delete_bkgraph(f);
-	return buf;
+	return caryll_write_bk(root);
 }
 
 caryll_buffer *caryll_write_chaining_classes(otl_subtable *_subtable) {
@@ -565,14 +561,9 @@ caryll_buffer *caryll_write_chaining_classes(otl_subtable *_subtable) {
 		}
 	}
 
-	caryll_bkgraph *f = caryll_bkgraph_from_block(root);
-	caryll_minimize_bkgraph(f);
-	caryll_buffer *buf = caryll_write_bkgraph(f);
-	caryll_delete_bkgraph(f);
-
 	free(coverage);
 	free(rcpg);
-	return buf;
+	return caryll_write_bk(root);
 }
 
 caryll_buffer *caryll_write_chaining(otl_subtable *_subtable) {

--- a/lib/tables/otl/chaining.c
+++ b/lib/tables/otl/chaining.c
@@ -460,7 +460,6 @@ otl_subtable *caryll_chaining_from_json(json_value *_subtable) {
 }
 
 caryll_buffer *caryll_write_chaining_coverage(otl_subtable *_subtable) {
-	caryll_buffer *bufst = bufnew();
 	subtable_chaining *subtable = &(_subtable->chaining);
 	otl_chaining_rule *rule = subtable->rules[0];
 	uint16_t nBacktrack = rule->inputBegins;
@@ -469,54 +468,53 @@ caryll_buffer *caryll_write_chaining_coverage(otl_subtable *_subtable) {
 	uint16_t nSubst = rule->applyCount;
 	reverseBacktracks(rule);
 
-	bufwrite16b(bufst, 3); // By coverage
-	size_t offset = 10 + 2 * rule->matchCount + 4 * rule->applyCount;
-	bufwrite16b(bufst, nBacktrack);
-	size_t cp = bufst->cursor;
+	caryll_bkblock *root = new_bkblock(b16, 3, // format
+	                                   bkover);
+
+	bkblock_push(root, b16, nBacktrack, bkover);
 	for (uint16_t j = 0; j < rule->inputBegins; j++) {
-		bufpingpong16b(bufst, caryll_write_coverage(rule->match[j]), &offset, &cp);
+		bkblock_push(root, p16, new_bkblock_from_buffer(caryll_write_coverage(rule->match[j])), bkover);
 	}
-	bufwrite16b(bufst, nInput);
+	bkblock_push(root, b16, nInput, bkover);
 	for (uint16_t j = rule->inputBegins; j < rule->inputEnds; j++) {
-		bufpingpong16b(bufst, caryll_write_coverage(rule->match[j]), &offset, &cp);
+		bkblock_push(root, p16, new_bkblock_from_buffer(caryll_write_coverage(rule->match[j])), bkover);
 	}
-	bufwrite16b(bufst, nLookahead);
+	bkblock_push(root, b16, nLookahead, bkover);
 	for (uint16_t j = rule->inputEnds; j < rule->matchCount; j++) {
-		bufpingpong16b(bufst, caryll_write_coverage(rule->match[j]), &offset, &cp);
+		bkblock_push(root, p16, new_bkblock_from_buffer(caryll_write_coverage(rule->match[j])), bkover);
 	}
-	bufwrite16b(bufst, rule->applyCount);
+	bkblock_push(root, b16, rule->applyCount, bkover);
 	for (uint16_t j = 0; j < nSubst; j++) {
-		bufwrite16b(bufst, rule->apply[j].index - nBacktrack);
-		bufwrite16b(bufst, rule->apply[j].lookup.index);
+		bkblock_push(root, b16, rule->apply[j].index - nBacktrack, // position
+		             b16, rule->apply[j].lookup.index,             // lookup
+		             bkover);
 	}
-	return bufst;
+
+	caryll_bkgraph *f = caryll_bkgraph_from_block(root);
+	caryll_minimize_bkgraph(f);
+	caryll_buffer *buf = caryll_write_bkgraph(f);
+	caryll_delete_bkgraph(f);
+	return buf;
 }
+
 caryll_buffer *caryll_write_chaining_classes(otl_subtable *_subtable) {
-	caryll_buffer *buf = bufnew();
 	subtable_chaining *subtable = &(_subtable->chaining);
-	// write coverage and class definitions
-	caryll_buffer *after = bufnew();
+
 	otl_coverage *coverage;
 	NEW(coverage);
 	coverage->numGlyphs = subtable->ic->numGlyphs;
 	coverage->glyphs = subtable->ic->glyphs;
-	bufwrite_bufdel(after, caryll_write_coverage(coverage));
-	size_t offsetbc = after->cursor;
-	bufwrite_bufdel(after, caryll_write_classdef(subtable->bc));
-	size_t offsetic = after->cursor;
-	bufwrite_bufdel(after, caryll_write_classdef(subtable->ic));
-	size_t offsetfc = after->cursor;
-	bufwrite_bufdel(after, caryll_write_classdef(subtable->fc));
 
-	// write rules
-	bufwrite16b(buf, 2);                          // by class
-	bufwrite16b(buf, 0);                          // coverage offset -- fill later
-	bufwrite16b(buf, 0);                          // bc offset -- fill later
-	bufwrite16b(buf, 0);                          // ic offset -- fill later
-	bufwrite16b(buf, 0);                          // fc offset -- fill later
-	bufwrite16b(buf, subtable->ic->maxclass + 1); // nclasses of ic;
+	caryll_bkblock *root =
+	    new_bkblock(b16, 2,                                                            // format
+	                p16, new_bkblock_from_buffer(caryll_write_coverage(coverage)),     // coverage
+	                p16, new_bkblock_from_buffer(caryll_write_classdef(subtable->bc)), // BacktrackClassDef
+	                p16, new_bkblock_from_buffer(caryll_write_classdef(subtable->ic)), // InputClassDef
+	                p16, new_bkblock_from_buffer(caryll_write_classdef(subtable->fc)), // LookaheadClassDef
+	                b16, subtable->ic->maxclass + 1,                                   // ChainSubClassSetCnt
+	                bkover);
 
-	uint16_t *rcpg, totalSets = 0, totalRules = 0;
+	uint16_t *rcpg;
 	NEW_N(rcpg, subtable->ic->maxclass + 1);
 	for (uint16_t j = 0; j <= subtable->ic->maxclass; j++) {
 		rcpg[j] = 0;
@@ -527,72 +525,53 @@ caryll_buffer *caryll_write_chaining_classes(otl_subtable *_subtable) {
 		if (startClass <= subtable->ic->maxclass) rcpg[startClass] += 1;
 	}
 
-	for (uint16_t j = 0; j <= subtable->ic->maxclass; j++)
-		if (rcpg[j]) { totalSets++, totalRules += rcpg[j]; }
-
-	// we are using a three-level ping-pong to maintain this fxxxing table
-	size_t setsOffset = buf->cursor + 2 + subtable->ic->maxclass * 2;
-	size_t rulesOffset = setsOffset + totalSets * 2 + totalRules * 2;
 	for (uint16_t j = 0; j <= subtable->ic->maxclass; j++) {
 		if (rcpg[j]) {
-			bufwrite16b(buf, setsOffset);
-			size_t cp = buf->cursor;
-			bufseek(buf, setsOffset);
-			bufwrite16b(buf, rcpg[j]);
+			caryll_bkblock *cset = new_bkblock(b16, rcpg[j], // ChainSubClassRuleCnt
+			                                   bkover);
 			for (uint16_t k = 0; k < subtable->rulesCount; k++) {
 				otl_chaining_rule *rule = subtable->rules[k];
 				uint16_t startClass = rule->match[rule->inputBegins]->glyphs[0].index;
-				if (startClass == j) {
-					reverseBacktracks(rule);
-					bufwrite16b(buf, rulesOffset - setsOffset);
-					size_t xcp = buf->cursor;
-					bufseek(buf, rulesOffset);
-
-					uint16_t nBacktrack = rule->inputBegins;
-					uint16_t nInput = rule->inputEnds - rule->inputBegins;
-					uint16_t nLookahead = rule->matchCount - rule->inputEnds;
-					uint16_t nSubst = rule->applyCount;
-
-					bufwrite16b(buf, nBacktrack);
-					for (uint16_t m = 0; m < rule->inputBegins; m++) {
-						bufwrite16b(buf, rule->match[m]->glyphs[0].index);
-					}
-					bufwrite16b(buf, nInput);
-					for (uint16_t m = rule->inputBegins + 1; m < rule->inputEnds; m++) {
-						bufwrite16b(buf, rule->match[m]->glyphs[0].index);
-					}
-					bufwrite16b(buf, nLookahead);
-					for (uint16_t m = rule->inputEnds; m < rule->matchCount; m++) {
-						bufwrite16b(buf, rule->match[m]->glyphs[0].index);
-					}
-					bufwrite16b(buf, nSubst);
-					for (uint16_t m = 0; m < nSubst; m++) {
-						bufwrite16b(buf, rule->apply[m].index - nBacktrack);
-						bufwrite16b(buf, rule->apply[m].lookup.index);
-					}
-
-					rulesOffset = buf->cursor;
-					bufseek(buf, xcp);
+				if (startClass != j) { continue; }
+				reverseBacktracks(rule);
+				uint16_t nBacktrack = rule->inputBegins;
+				uint16_t nInput = rule->inputEnds - rule->inputBegins;
+				uint16_t nLookahead = rule->matchCount - rule->inputEnds;
+				uint16_t nSubst = rule->applyCount;
+				caryll_bkblock *r = new_bkblock(bkover);
+				bkblock_push(r, b16, nBacktrack, bkover);
+				for (uint16_t m = 0; m < rule->inputBegins; m++) {
+					bkblock_push(r, b16, rule->match[m]->glyphs[0].index, bkover);
 				}
+				bkblock_push(r, b16, nInput, bkover);
+				for (uint16_t m = rule->inputBegins + 1; m < rule->inputEnds; m++) {
+					bkblock_push(r, b16, rule->match[m]->glyphs[0].index, bkover);
+				}
+				bkblock_push(r, b16, nLookahead, bkover);
+				for (uint16_t m = rule->inputEnds; m < rule->matchCount; m++) {
+					bkblock_push(r, b16, rule->match[m]->glyphs[0].index, bkover);
+				}
+				bkblock_push(r, b16, nSubst, bkover);
+				for (uint16_t m = 0; m < nSubst; m++) {
+					bkblock_push(r, b16, rule->apply[m].index - nBacktrack, // position
+					             b16, rule->apply[m].lookup.index,          // lookup index
+					             bkover);
+				}
+				bkblock_push(cset, p16, r, bkover);
 			}
-			setsOffset = buf->cursor;
-			bufseek(buf, cp);
+			bkblock_push(root, p16, cset, bkover);
 		} else {
-			bufwrite16b(buf, 0);
+			bkblock_push(root, p16, NULL, bkover);
 		}
 	}
 
-	// so, how far have we reached?
-	size_t afterOffset = buflen(buf);
-	bufseek(buf, afterOffset);
-	bufwrite_bufdel(buf, after);
-	bufseek(buf, 2);
-	bufwrite16b(buf, afterOffset);
-	bufwrite16b(buf, afterOffset + offsetbc);
-	bufwrite16b(buf, afterOffset + offsetic);
-	bufwrite16b(buf, afterOffset + offsetfc);
+	caryll_bkgraph *f = caryll_bkgraph_from_block(root);
+	caryll_minimize_bkgraph(f);
+	caryll_buffer *buf = caryll_write_bkgraph(f);
+	caryll_delete_bkgraph(f);
 
 	free(coverage);
+	free(rcpg);
 	return buf;
 }
 

--- a/lib/tables/otl/gpos-common.c
+++ b/lib/tables/otl/gpos-common.c
@@ -138,6 +138,14 @@ void write_gpos_value(caryll_buffer *buf, otl_position_value v, uint16_t format)
 	if (format & FORMAT_DHEIGHT) bufwrite16b(buf, v.dHeight);
 }
 
+caryll_bkblock *bk_gpos_value(otl_position_value v, uint16_t format) {
+	caryll_bkblock *b = new_bkblock(bkover);
+	if (format & FORMAT_DX) bkblock_push(b, b16, v.dx, bkover);
+	if (format & FORMAT_DY) bkblock_push(b, b16, v.dy, bkover);
+	if (format & FORMAT_DWIDTH) bkblock_push(b, b16, v.dWidth, bkover);
+	if (format & FORMAT_DHEIGHT) bkblock_push(b, b16, v.dHeight, bkover);
+}
+
 // Anchor functions
 int getPositon(otl_anchor anchor) {
 	return ((uint16_t)anchor.x) << 16 | ((uint16_t)anchor.y);

--- a/lib/tables/otl/gpos-common.c
+++ b/lib/tables/otl/gpos-common.c
@@ -66,6 +66,14 @@ FAIL:
 	return NULL;
 }
 
+caryll_bkblock *bkFromAnchor(otl_anchor a) {
+	if (!a.present) return NULL;
+	return new_bkblock(b16, 1,   // format
+	                   b16, a.x, // x
+	                   b16, a.y, // y
+	                   bkover);
+}
+
 // GPOS position value constants
 const uint8_t FORMAT_DX = 1;
 const uint8_t FORMAT_DY = 2;

--- a/lib/tables/otl/gpos-common.c
+++ b/lib/tables/otl/gpos-common.c
@@ -144,6 +144,7 @@ caryll_bkblock *bk_gpos_value(otl_position_value v, uint16_t format) {
 	if (format & FORMAT_DY) bkblock_push(b, b16, v.dy, bkover);
 	if (format & FORMAT_DWIDTH) bkblock_push(b, b16, v.dWidth, bkover);
 	if (format & FORMAT_DHEIGHT) bkblock_push(b, b16, v.dHeight, bkover);
+	return b;
 }
 
 // Anchor functions

--- a/lib/tables/otl/gpos-common.h
+++ b/lib/tables/otl/gpos-common.h
@@ -8,6 +8,7 @@ otl_anchor otl_anchor_absent();
 otl_anchor otl_read_anchor(font_file_pointer data, uint32_t tableLength, uint32_t offset);
 json_value *otl_anchor_to_json(otl_anchor a);
 otl_anchor otl_anchor_from_json(json_value *v);
+caryll_bkblock *bkFromAnchor(otl_anchor a);
 
 // mark arrays
 void otl_delete_mark_array(otl_mark_array *array);

--- a/lib/tables/otl/gpos-common.h
+++ b/lib/tables/otl/gpos-common.h
@@ -26,6 +26,8 @@ otl_position_value position_zero();
 otl_position_value read_gpos_value(font_file_pointer data, uint32_t tableLength, uint32_t offset, uint16_t format);
 uint8_t required_position_format(otl_position_value v);
 void write_gpos_value(caryll_buffer *buf, otl_position_value v, uint16_t format);
+caryll_bkblock *bk_gpos_value(otl_position_value v, uint16_t format);
+
 json_value *gpos_value_to_json(otl_position_value value);
 otl_position_value gpos_value_from_json(json_value *pos);
 

--- a/lib/tables/otl/gpos-cursive.c
+++ b/lib/tables/otl/gpos-cursive.c
@@ -86,52 +86,24 @@ otl_subtable *caryll_gpos_cursive_from_json(json_value *_subtable) {
 }
 
 caryll_buffer *caryll_write_gpos_cursive(otl_subtable *_subtable) {
-	anchor_aggeration_hash *agh = NULL, *s, *tmp;
 	subtable_gpos_cursive *subtable = &(_subtable->gpos_cursive);
+
+	caryll_bkblock *root =
+	    new_bkblock(b16, 1,                                                                  // format
+	                p16, new_bkblock_from_buffer(caryll_write_coverage(subtable->coverage)), // Coverage
+	                b16, subtable->coverage->numGlyphs,                                      // EntryExitCount
+	                bkover);
 	for (uint16_t j = 0; j < subtable->coverage->numGlyphs; j++) {
-		ANCHOR_AGGERATOR_PUSH(agh, subtable->enter[j]);
-		ANCHOR_AGGERATOR_PUSH(agh, subtable->exit[j]);
+		bkblock_push(root,                                  // EntryExitRecord[.]
+		             p16, bkFromAnchor(subtable->enter[j]), // enter
+		             p16, bkFromAnchor(subtable->exit[j]),  // exit
+		             bkover);
 	}
-	HASH_SORT(agh, byAnchorIndex);
-	caryll_buffer *buf = bufnew();
-	bufwrite16b(buf, 1);
-	size_t covOffset = 6 + 4 * subtable->coverage->numGlyphs;
-	size_t cp = buf->cursor;
-	bufpingpong16b(buf, caryll_write_coverage(subtable->coverage), &covOffset, &cp);
-	bufwrite16b(buf, subtable->coverage->numGlyphs);
-	for (uint16_t j = 0; j < subtable->coverage->numGlyphs; j++) {
-		if (subtable->enter[j].present) {
-			anchor_aggeration_hash *s;
-			int position = getPositon(subtable->enter[j]);
-			HASH_FIND_INT(agh, &position, s);
-			if (s) {
-				bufwrite16b(buf, covOffset + s->index * 6);
-			} else {
-				bufwrite16b(buf, 0);
-			}
-		} else {
-			bufwrite16b(buf, 0);
-		}
-		if (subtable->exit[j].present) {
-			anchor_aggeration_hash *s;
-			int position = getPositon(subtable->exit[j]);
-			HASH_FIND_INT(agh, &position, s);
-			if (s) {
-				bufwrite16b(buf, covOffset + s->index * 6);
-			} else {
-				bufwrite16b(buf, 0);
-			}
-		} else {
-			bufwrite16b(buf, 0);
-		}
-	}
-	bufseek(buf, covOffset);
-	HASH_ITER(hh, agh, s, tmp) {
-		bufwrite16b(buf, 1);
-		bufwrite16b(buf, s->x);
-		bufwrite16b(buf, s->y);
-		HASH_DEL(agh, s);
-		free(s);
-	}
+
+	caryll_bkgraph *f = caryll_bkgraph_from_block(root);
+	caryll_minimize_bkgraph(f);
+	caryll_buffer *buf = caryll_write_bkgraph(f);
+	caryll_delete_bkgraph(f);
+
 	return buf;
 }

--- a/lib/tables/otl/gpos-cursive.c
+++ b/lib/tables/otl/gpos-cursive.c
@@ -100,10 +100,5 @@ caryll_buffer *caryll_write_gpos_cursive(otl_subtable *_subtable) {
 		             bkover);
 	}
 
-	caryll_bkgraph *f = caryll_bkgraph_from_block(root);
-	caryll_minimize_bkgraph(f);
-	caryll_buffer *buf = caryll_write_bkgraph(f);
-	caryll_delete_bkgraph(f);
-
-	return buf;
+	return caryll_write_bk(root);
 }

--- a/lib/tables/otl/gpos-mark-to-ligature.c
+++ b/lib/tables/otl/gpos-mark-to-ligature.c
@@ -270,9 +270,5 @@ caryll_buffer *caryll_write_gpos_mark_to_ligature(otl_subtable *_subtable) {
 
 	bkblock_push(root, p16, markArray, p16, ligatureArray, bkover);
 
-	caryll_bkgraph *f = caryll_bkgraph_from_block(root);
-	caryll_minimize_bkgraph(f);
-	caryll_buffer *buf = caryll_write_bkgraph(f);
-	caryll_delete_bkgraph(f);
-	return buf;
+	return caryll_write_bk(root);
 }

--- a/lib/tables/otl/gpos-mark-to-single.c
+++ b/lib/tables/otl/gpos-mark-to-single.c
@@ -227,10 +227,5 @@ caryll_buffer *caryll_write_gpos_mark_to_single(otl_subtable *_subtable) {
 
 	bkblock_push(root, p16, markArray, p16, baseArray, bkover);
 
-	caryll_bkgraph *f = caryll_bkgraph_from_block(root);
-	caryll_minimize_bkgraph(f);
-	caryll_buffer *buf = caryll_write_bkgraph(f);
-	caryll_delete_bkgraph(f);
-
-	return buf;
+	return caryll_write_bk(root);
 }

--- a/lib/tables/otl/gsub-ligature.c
+++ b/lib/tables/otl/gsub-ligature.c
@@ -204,15 +204,10 @@ caryll_buffer *caryll_write_gsub_ligature_subtable(otl_subtable *_subtable) {
 		bkblock_push(root, p16, ligset, bkover);
 	}
 
-	caryll_bkgraph *f = caryll_bkgraph_from_block(root);
-	caryll_minimize_bkgraph(f);
-	caryll_buffer *buf = caryll_write_bkgraph(f);
-	caryll_delete_bkgraph(f);
-
 	caryll_delete_coverage(startcov);
 	HASH_ITER(hh, h, s, tmp) {
 		HASH_DEL(h, s);
 		free(s);
 	}
-	return buf;
+	return caryll_write_bk(root);
 }

--- a/lib/tables/otl/gsub-ligature.c
+++ b/lib/tables/otl/gsub-ligature.c
@@ -150,8 +150,8 @@ static int by_gid(ligature_aggerator *a, ligature_aggerator *b) {
 }
 
 caryll_buffer *caryll_write_gsub_ligature_subtable(otl_subtable *_subtable) {
-	caryll_buffer *buf = bufnew();
 	subtable_gsub_ligature *subtable = &(_subtable->gsub_ligature);
+
 	ligature_aggerator *h = NULL, *s, *tmp;
 	uint16_t nLigatures = subtable->to->numGlyphs;
 	for (uint16_t j = 0; j < nLigatures; j++) {
@@ -166,46 +166,50 @@ caryll_buffer *caryll_write_gsub_ligature_subtable(otl_subtable *_subtable) {
 	}
 	HASH_SORT(h, by_gid);
 
-	otl_coverage *startCoverage;
-	NEW(startCoverage);
-	startCoverage->numGlyphs = HASH_COUNT(h);
-	NEW_N(startCoverage->glyphs, startCoverage->numGlyphs);
+	otl_coverage *startcov;
+	NEW(startcov);
+	startcov->numGlyphs = HASH_COUNT(h);
+	NEW_N(startcov->glyphs, startcov->numGlyphs);
 
 	uint16_t jj = 0;
 	foreach_hash(s, h) {
 		s->ligid = jj;
-		startCoverage->glyphs[jj].index = s->gid;
-		startCoverage->glyphs[jj].name = NULL;
+		startcov->glyphs[jj].index = s->gid;
+		startcov->glyphs[jj].name = NULL;
 		jj++;
 	}
 
-	// start writing
-	bufwrite16b(buf, 1);
-	size_t offset = 6 + 4 * startCoverage->numGlyphs + nLigatures * 2;
-	size_t setOffset = 6 + 2 * startCoverage->numGlyphs;
-	size_t cp = buf->cursor;
-	bufpingpong16b(buf, caryll_write_coverage(startCoverage), &offset, &cp);
-	bufwrite16b(buf, startCoverage->numGlyphs);
+	caryll_bkblock *root = new_bkblock(b16, 1,                                                        // format
+	                                   p16, new_bkblock_from_buffer(caryll_write_coverage(startcov)), // coverage
+	                                   b16, startcov->numGlyphs,                                      // LigSetCount
+	                                   bkover);
+
 	foreach_hash(s, h) {
-		bufping16b(buf, &setOffset, &cp);
 		uint16_t nLigsHere = 0;
 		for (uint16_t j = 0; j < nLigatures; j++)
 			if (subtable->from[j]->glyphs[0].index == s->gid) nLigsHere++;
-		bufwrite16b(buf, nLigsHere);
-		size_t scp = buf->cursor;
-		for (uint16_t j = 0; j < nLigatures; j++)
+		caryll_bkblock *ligset = new_bkblock(b16, nLigsHere, bkover);
+
+		for (uint16_t j = 0; j < nLigatures; j++) {
 			if (subtable->from[j]->glyphs[0].index == s->gid) {
-				bufping16bd(buf, &offset, &setOffset, &scp);
-				bufwrite16b(buf, subtable->to->glyphs[j].index);
-				bufwrite16b(buf, subtable->from[j]->numGlyphs);
+				caryll_bkblock *ligdef = new_bkblock(b16, subtable->to->glyphs[j].index, // ligGlyph
+				                                     b16, subtable->from[j]->numGlyphs,  // compCount
+				                                     bkover);
 				for (uint16_t m = 1; m < subtable->from[j]->numGlyphs; m++) {
-					bufwrite16b(buf, subtable->from[j]->glyphs[m].index);
+					bkblock_push(ligdef, b16, subtable->from[j]->glyphs[m].index, bkover);
 				}
-				bufpong(buf, &offset, &scp);
+				bkblock_push(ligset, p16, ligdef, bkover);
 			}
-		bufpong(buf, &setOffset, &cp);
+		}
+		bkblock_push(root, p16, ligset, bkover);
 	}
-	caryll_delete_coverage(startCoverage);
+
+	caryll_bkgraph *f = caryll_bkgraph_from_block(root);
+	caryll_minimize_bkgraph(f);
+	caryll_buffer *buf = caryll_write_bkgraph(f);
+	caryll_delete_bkgraph(f);
+
+	caryll_delete_coverage(startcov);
 	HASH_ITER(hh, h, s, tmp) {
 		HASH_DEL(h, s);
 		free(s);

--- a/lib/tables/otl/gsub-multi.c
+++ b/lib/tables/otl/gsub-multi.c
@@ -88,20 +88,17 @@ otl_subtable *caryll_gsub_multi_from_json(json_value *_subtable) {
 
 caryll_buffer *caryll_write_gsub_multi_subtable(otl_subtable *_subtable) {
 	subtable_gsub_multi *subtable = &(_subtable->gsub_multi);
-	caryll_buffer *buf = bufnew();
-	bufwrite16b(buf, 1);
 
-	size_t offset = 6 + 2 * subtable->from->numGlyphs;
-	size_t cp = buf->cursor;
-	bufpingpong16b(buf, caryll_write_coverage(subtable->from), &offset, &cp);
-	bufwrite16b(buf, subtable->from->numGlyphs);
+	caryll_bkblock *root = new_bkblock(b16, 1,                                                              // format
+	                                   p16, new_bkblock_from_buffer(caryll_write_coverage(subtable->from)), // coverage
+	                                   b16, subtable->from->numGlyphs,                                      // quantity
+	                                   bkover);
 	for (uint16_t j = 0; j < subtable->from->numGlyphs; j++) {
-		bufping16b(buf, &offset, &cp);
-		bufwrite16b(buf, subtable->to[j]->numGlyphs);
+		caryll_bkblock *b = new_bkblock(b16, subtable->to[j]->numGlyphs, bkover);
 		for (uint16_t k = 0; k < subtable->to[j]->numGlyphs; k++) {
-			bufwrite16b(buf, subtable->to[j]->glyphs[k].index);
+			bkblock_push(b, b16, subtable->to[j]->glyphs[k].index, bkover);
 		}
-		bufpong(buf, &offset, &cp);
+		bkblock_push(root, p16, b, bkover);
 	}
-	return buf;
+	return caryll_write_bk(root);
 }

--- a/lib/tables/otl/gsub-reverse.c
+++ b/lib/tables/otl/gsub-reverse.c
@@ -119,25 +119,27 @@ otl_subtable *caryll_gsub_reverse_from_json(json_value *_subtable) {
 	subtable->to = caryll_coverage_from_json(_to);
 	return _st;
 }
+
 caryll_buffer *caryll_write_gsub_reverse(otl_subtable *_subtable) {
-	caryll_buffer *buf = bufnew();
 	subtable_gsub_reverse *subtable = &(_subtable->gsub_reverse);
 	reverseBacktracks(subtable);
-	bufwrite16b(buf, 1);
-	size_t offset = 10 + 2 * (subtable->matchCount + subtable->to->numGlyphs);
-	size_t cp = buf->cursor;
-	bufpingpong16b(buf, caryll_write_coverage(subtable->match[subtable->inputIndex]), &offset, &cp);
-	bufwrite16b(buf, subtable->inputIndex);
+
+	caryll_bkblock *root = new_bkblock(
+	    b16, 1,                                                                                     // format
+	    p16, new_bkblock_from_buffer(caryll_write_coverage(subtable->match[subtable->inputIndex])), // coverage
+	    bkover);
+	bkblock_push(root, b16, subtable->inputIndex, bkover);
 	for (uint16_t j = 0; j < subtable->inputIndex; j++) {
-		bufpingpong16b(buf, caryll_write_coverage(subtable->match[j]), &offset, &cp);
+		bkblock_push(root, p16, new_bkblock_from_buffer(caryll_write_coverage(subtable->match[j])), bkover);
 	}
-	bufwrite16b(buf, subtable->matchCount - subtable->inputIndex - 1);
+	bkblock_push(root, b16, subtable->matchCount - subtable->inputIndex - 1, bkover);
 	for (uint16_t j = subtable->inputIndex + 1; j < subtable->matchCount; j++) {
-		bufpingpong16b(buf, caryll_write_coverage(subtable->match[j]), &offset, &cp);
+		bkblock_push(root, p16, new_bkblock_from_buffer(caryll_write_coverage(subtable->match[j])), bkover);
 	}
-	bufwrite16b(buf, subtable->to->numGlyphs);
+	bkblock_push(root, b16, subtable->to->numGlyphs, bkover);
 	for (uint16_t j = 0; j < subtable->to->numGlyphs; j++) {
-		bufwrite16b(buf, subtable->to->glyphs[j].index);
+		bkblock_push(root, b16, subtable->to->glyphs[j].index, bkover);
 	}
-	return buf;
+
+	return caryll_write_bk(root);
 }

--- a/lib/tables/otl/otl.c
+++ b/lib/tables/otl/otl.c
@@ -31,7 +31,7 @@ otl_subtable *caryll_read_otl_subtable(font_file_pointer data, uint32_t tableLen
                                        otl_lookup_type lookupType);
 static void _lookup_to_json(otl_lookup *lookup, json_value *dump);
 static bool _parse_lookup(json_value *lookup, char *lookupName, lookup_hash **lh);
-static bool _write_subtable(otl_lookup *lookup, caryll_buffer *buf, uint32_t **subtableOffsets, uint32_t *lastOffset);
+static bool _write_subtable(otl_lookup *lookup, caryll_buffer ***subtables, size_t *lastOffset);
 
 // COMMON PART
 table_otl *caryll_new_otl() {
@@ -717,14 +717,13 @@ FAIL:
 }
 
 static bool _declare_lookup_writer(otl_lookup_type type, caryll_buffer *(*fn)(otl_subtable *_subtable),
-                                   otl_lookup *lookup, caryll_buffer *buf, uint32_t **subtableOffsets,
-                                   uint32_t *lastOffset) {
+                                   otl_lookup *lookup, caryll_buffer ***subtables, size_t *lastOffset) {
 	if (lookup->type == type) {
-		NEW_N(*subtableOffsets, lookup->subtableCount);
+		NEW_N(*subtables, lookup->subtableCount);
 		for (uint16_t j = 0; j < lookup->subtableCount; j++) {
-			(*subtableOffsets)[j] = (uint32_t)buf->cursor;
-			*lastOffset = (uint32_t)buf->cursor;
-			bufwrite_bufdel(buf, fn(lookup->subtables[j]));
+			caryll_buffer *buf = fn(lookup->subtables[j]);
+			(*subtables)[j] = buf;
+			*lastOffset += buf->size;
 		}
 		return true;
 	}
@@ -732,20 +731,18 @@ static bool _declare_lookup_writer(otl_lookup_type type, caryll_buffer *(*fn)(ot
 }
 
 // When writing lookups, otfcc will try to maintain everything correctly.
+// That is, we will use extended layout lookups automatically when the
+// offsets are too large.
 static caryll_buffer *writeOTLLookups(table_otl *table, const caryll_options *options, const char *tag) {
-	caryll_buffer *bufl = bufnew();
-	caryll_buffer *bufsts = bufnew();
-	uint32_t **subtableOffsets;
-	NEW_N(subtableOffsets, table->lookupCount);
+	caryll_buffer ***subtables;
+	NEW_N(subtables, table->lookupCount);
 	bool *lookupWritten;
 	NEW_N(lookupWritten, table->lookupCount);
-
-	uint32_t lastOffset = 0;
+	size_t lastOffset = 0;
 	for (uint16_t j = 0; j < table->lookupCount; j++) {
-		subtableOffsets[j] = NULL;
-		lookupWritten[j] = _write_subtable(table->lookups[j], bufsts, &(subtableOffsets[j]), &lastOffset);
+		subtables[j] = NULL;
+		lookupWritten[j] = _write_subtable(table->lookups[j], &(subtables[j]), &lastOffset);
 	}
-	// estimate the length of headers
 	size_t headerSize = 2 + 2 * table->lookupCount;
 	for (uint16_t j = 0; j < table->lookupCount; j++) {
 		if (lookupWritten[j]) { headerSize += 6 + 2 * table->lookups[j]->subtableCount; }
@@ -757,68 +754,52 @@ static caryll_buffer *writeOTLLookups(table_otl *table, const caryll_options *op
 			if (lookupWritten[j]) { headerSize += 8 * table->lookups[j]->subtableCount; }
 		}
 	}
-	// write the header
-	bufwrite16b(bufl, table->lookupCount);
-	size_t hp = bufl->cursor;
-	bufseek(bufl, 2 + table->lookupCount * 2);
+
+	caryll_bkblock *root = new_bkblock(b16, table->lookupCount, // LookupCount
+	                                   bkover);
 	for (uint16_t j = 0; j < table->lookupCount; j++) {
 		if (!lookupWritten[j]) {
 			fprintf(stderr, "Lookup %s not written.\n", table->lookups[j]->name);
 			continue;
 		}
-
 		otl_lookup *lookup = table->lookups[j];
-		size_t lookupOffset = bufl->cursor;
-		if (lookupOffset > 0xFFFF) {
-			fprintf(stderr, "[OTFCC-fea] Warning, Lookup %s Written at 0x%" PRIx32 ", "
-			                "this lookup may be corrupted.\n",
-			        table->lookups[j]->name, (uint32_t)lookupOffset);
-		}
-		// lookup type
-		if (useExtended) {
-			bufwrite16b(
-			    bufl, (lookup->type > otl_type_gpos_unknown
-			               ? otl_type_gpos_extend - otl_type_gpos_unknown
-			               : lookup->type > otl_type_gsub_unknown ? otl_type_gsub_extend - otl_type_gsub_unknown : 0));
-		} else {
-			bufwrite16b(bufl, (lookup->type > otl_type_gpos_unknown
-			                       ? lookup->type - otl_type_gpos_unknown
-			                       : lookup->type > otl_type_gsub_unknown ? lookup->type - otl_type_gsub_unknown : 0));
-		}
-		// lookup flags
-		bufwrite16b(bufl, lookup->flags);
-		bufwrite16b(bufl, lookup->subtableCount);
-		if (useExtended) {
-			for (uint16_t k = 0; k < lookup->subtableCount; k++) { // subtable offsets
-				bufwrite16b(bufl, 6 + 2 * lookup->subtableCount + 8 * k);
-			}
-			for (uint16_t k = 0; k < lookup->subtableCount; k++) { // extension subtables
-				size_t subtableStart = bufl->cursor;
-				bufwrite16b(bufl, 1);
-				bufwrite16b(bufl,
-				            (lookup->type > otl_type_gpos_unknown
-				                 ? lookup->type - otl_type_gpos_unknown
-				                 : lookup->type > otl_type_gsub_unknown ? lookup->type - otl_type_gsub_unknown : 0));
-				bufwrite32b(bufl, (uint32_t)(subtableOffsets[j][k] + headerSize - subtableStart));
-			}
-		} else {
-			for (uint16_t k = 0; k < lookup->subtableCount; k++) { // subtable offsets
-				bufwrite16b(bufl, subtableOffsets[j][k] + headerSize - lookupOffset);
-			}
-		}
-		free(subtableOffsets[j]);
-		size_t cp = bufl->cursor;
+		uint16_t lookupType =
+		    useExtended
+		        ? (lookup->type > otl_type_gpos_unknown
+		               ? otl_type_gpos_extend - otl_type_gpos_unknown
+		               : lookup->type > otl_type_gsub_unknown ? otl_type_gsub_extend - otl_type_gsub_unknown : 0)
+		        : (lookup->type > otl_type_gpos_unknown
+		               ? lookup->type - otl_type_gpos_unknown
+		               : lookup->type > otl_type_gsub_unknown ? lookup->type - otl_type_gsub_unknown : 0);
 
-		bufseek(bufl, hp);
-		bufwrite16b(bufl, lookupOffset);
-		hp = bufl->cursor;
-		bufseek(bufl, cp);
+		caryll_bkblock *blk = new_bkblock(b16, lookupType,            // LookupType
+		                                  b16, lookup->flags,         // LookupFlag
+		                                  b16, lookup->subtableCount, // SubTableCount
+		                                  bkover);
+		for (uint16_t k = 0; k < lookup->subtableCount; k++) {
+			if (useExtended) {
+				uint16_t extensionLookupType =
+				    lookup->type > otl_type_gpos_unknown
+				        ? lookup->type - otl_type_gpos_unknown
+				        : lookup->type > otl_type_gsub_unknown ? lookup->type - otl_type_gsub_unknown : 0;
+
+				caryll_bkblock *stub = new_bkblock(b16, 1,                                        // format
+				                                   b16, extensionLookupType,                      // ExtensionLookupType
+				                                   p32, new_bkblock_from_buffer(subtables[j][k]), // ExtensionOffset
+				                                   bkover);
+				bkblock_push(blk, p16, stub, bkover);
+			} else {
+				bkblock_push(blk, p16, new_bkblock_from_buffer(subtables[j][k]), bkover);
+			}
+		}
+		bkblock_push(blk, b16, 0, // MarkFilteringSet
+		             bkover);
+		bkblock_push(root, p16, blk, bkover);
+		free(subtables[j]);
 	}
-	free(subtableOffsets);
+	free(subtables);
 	free(lookupWritten);
-	bufseek(bufl, headerSize);
-	bufwrite_bufdel(bufl, bufsts);
-	return bufl;
+	return caryll_write_bk(root);
 }
 
 static uint32_t featureNameToTag(sds name) {
@@ -987,7 +968,7 @@ caryll_buffer *caryll_write_otl(table_otl *table, const caryll_options *options,
 #define LOOKUP_PARSER(llt, parser)                                                                                     \
 	if (!parsed) { parsed = _declareLookupParser(tableNames[llt], llt, parser, lookup, lookupName, lh); }
 #define LOOKUP_WRITER(type, fn)                                                                                        \
-	if (!written) written = _declare_lookup_writer(type, fn, lookup, buf, subtableOffsets, lastOffset);
+	if (!written) written = _declare_lookup_writer(type, fn, lookup, subtables, lastOffset);
 static const char *tableNames[] = {[otl_type_unknown] = "unknown",
                                    [otl_type_gsub_unknown] = "gsub_unknown",
                                    [otl_type_gsub_single] = "gsub_single",
@@ -1090,7 +1071,7 @@ static bool _parse_lookup(json_value *lookup, char *lookupName, lookup_hash **lh
 	return parsed;
 }
 
-static bool _write_subtable(otl_lookup *lookup, caryll_buffer *buf, uint32_t **subtableOffsets, uint32_t *lastOffset) {
+static bool _write_subtable(otl_lookup *lookup, caryll_buffer ***subtables, size_t *lastOffset) {
 	bool written = false;
 	LOOKUP_WRITER(otl_type_gsub_single, caryll_write_gsub_single_subtable);
 	LOOKUP_WRITER(otl_type_gsub_multiple, caryll_write_gsub_multi_subtable);

--- a/lib/tables/otl/otl.h
+++ b/lib/tables/otl/otl.h
@@ -1,6 +1,7 @@
 #ifndef CARYLL_TABLES_OTL_H
 #define CARYLL_TABLES_OTL_H
 #include <support/util.h>
+#include <bk/bkgraph.h>
 #include <font/caryll-sfnt.h>
 
 typedef enum {


### PR DESCRIPTION
In this PR, I suggested a new mechanism for writing OTL-related tables, which is the `bk`.

As tested, it reduces 76KB (486KB → 410KB) on *Noto Nastaliq Urdu*.