### PR TITLE
quick.make: add macosx targets; fix otfccdll release/debug mix-up

### DIFF
--- a/quick.make
+++ b/quick.make
@@ -15,6 +15,8 @@ mf-ninja-windows :
 	@$(PREMAKE5) ninja --os=windows
 mf-ninja-linux :
 	@$(PREMAKE5) ninja --os=linux --cc=$(CC)
+mf-ninja-macosx :
+	@$(PREMAKE5) ninja --os=macosx
 
 mingw-debug-x64 : mf-gmake
 	@cd build/gmake && make config=debug_x64
@@ -26,13 +28,22 @@ mingw-release-x86 : mf-gmake
 	@cd build/gmake && make config=release_x86
 
 linux-debug-x64 : mf-ninja-linux
-	@cd build/ninja && $(NINJA_EXEC) otfccdump_debug_x64 otfccbuild_debug_x64 otfccdll_release_x64
+	@cd build/ninja && $(NINJA_EXEC) otfccdump_debug_x64 otfccbuild_debug_x64 otfccdll_debug_x64
 linux-debug-x86 : mf-ninja-linux
-	@cd build/ninja && $(NINJA_EXEC) otfccdump_debug_x86 otfccbuild_debug_x86 otfccdll_release_x86
+	@cd build/ninja && $(NINJA_EXEC) otfccdump_debug_x86 otfccbuild_debug_x86 otfccdll_debug_x86
 linux-release-x64 : mf-ninja-linux
-	@cd build/ninja && $(NINJA_EXEC) otfccdump_release_x64 otfccbuild_release_x64 otfccdll_debug_x64
+	@cd build/ninja && $(NINJA_EXEC) otfccdump_release_x64 otfccbuild_release_x64 otfccdll_release_x64
 linux-release-x86 : mf-ninja-linux
-	@cd build/ninja && $(NINJA_EXEC) otfccdump_release_x86 otfccbuild_release_x86 otfccdll_debug_x86
+	@cd build/ninja && $(NINJA_EXEC) otfccdump_release_x86 otfccbuild_release_x86 otfccdll_release_x86
+
+macosx-debug-x64 : mf-ninja-macosx
+	@cd build/ninja && $(NINJA_EXEC) otfccdump_debug_x64 otfccbuild_debug_x64 otfccdll_debug_x64
+macosx-debug-x86 : mf-ninja-macosx
+	@cd build/ninja && $(NINJA_EXEC) otfccdump_debug_x86 otfccbuild_debug_x86 otfccdll_debug_x86
+macosx-release-x64 : mf-ninja-macosx
+	@cd build/ninja && $(NINJA_EXEC) otfccdump_release_x64 otfccbuild_release_x64 otfccdll_release_x64
+macosx-release-x86 : mf-ninja-macosx
+	@cd build/ninja && $(NINJA_EXEC) otfccdump_release_x86 otfccbuild_release_x86 otfccdll_release_x86
 
 # VC does not support debugging well
 # It is used for release versions only


### PR DESCRIPTION
The `quick.make` file didn't have targets for building with macOS using premake5/ninja.

After this patch, one can just do this to build on mac, as an alternative to `premake5 xcode4 && xcodebuild ...`.

```sh
$ make -f quick.make macosx-release-x64
```

Using ninja is so much faster.

Also, I noticed that the release and debug targets for otfccdll were somehow mixed up. I fixed that as well.