### PR TITLE
令 AppVeyor 使用 VS 2017

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,10 @@
 environment:
-  VS_VERSION: vs2015
+  VS_VERSION: vs2017
 
 platform:
   - x64
 
-image: Previous Visual Studio 2017
+image: Visual Studio 2017
 
 configuration:
   - Release
@@ -12,10 +12,7 @@ configuration:
 install:
   - set PATH=C:\msys64\usr\bin;%PATH%
 
-before_build:
-  - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
-
 build_script:
-  - dep\bin-win\premake5.exe vs2015
-  - cmd /c _vcbuild64.bat /property:Configuration=Release
+  - dep\bin-win\premake5.exe vs2017
+  - msbuild build\vs\otfcc.sln /m:%NUMBER_OF_PROCESSORS% /nr:false /nologo /verbosity:minimal /property:Configuration=Release
   - make -f quick.make test


### PR DESCRIPTION
LLVM 7 不再建立 LLVM-vs2014 工具集，而使用扩展的方式。但是扩展似乎并不适用于 VS 2015。