### PR TITLE
Fix: broken pipe on Linux when stdin is a Linux socket

### DIFF
--- a/src/otfccbuild.c
+++ b/src/otfccbuild.c
@@ -92,7 +92,9 @@ void readEntireFile(char *inPath, char **_buffer, long *_length) {
 }
 
 void readEntireStdin(char **_buffer, long *_length) {
+#ifdef _WIN32
 	freopen(NULL, "rb", stdin);
+#endif
 	static const long BUF_SIZE = 0x400000;
 	static const long BUF_MIN = 0x1000;
 	char *buffer = malloc(BUF_SIZE);


### PR DESCRIPTION
...by making it only `freopen` stdin on Windows.

AFAIK the binary mode only has effect on Windows but not on POSIX systems, and if stdin is a Linux _socket_ (e.g. when spawned as a Node.js child process), `freopen` closes it immediately (even if the first argument is `NULL`) , then `otfccbuild` hangs after that.